### PR TITLE
Updated version to support LimeSurvey 7.x

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,7 +81,8 @@ For example :
 
 This plugin was tested with
 
-- A recent version v6.4.3 (PHP 8.1)
+- A recent version v7.0.9 (PHP 8.5)
+- v6.4.3 (PHP 8.1)
 - the latest stable release v5.2.5
 - the latest LTS release v3.27.28
 

--- a/config.xml
+++ b/config.xml
@@ -13,6 +13,7 @@
     </metadata>
 
     <compatibility>
+        <version>7</version>
         <version>6</version>
         <version>5</version>
         <version>4</version>


### PR DESCRIPTION
I've tested this plugin with Keycloak on LimeSurvey v7.0.9 (PHP 8.5), and it works as expected. 

More specifically I've used the [martialblog/limesurvey:7-apache](https://github.com/martialblog/docker-limesurvey/blob/master/7.0/apache/Dockerfile) docker image, which currently uses LimeSurvey v7.0.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility for LimeSurvey version 7.0.9 running on PHP 8.5.
  * Continued support for previously supported LimeSurvey versions.

* **Documentation**
  * Updated the supported versions list to include the latest tested version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->